### PR TITLE
Global Search 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out
 target/*
+bin/*
 .idea/*
 *.iml
 wrapper/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 out
 target/*
-bin/*
 .idea/*
 *.iml
 wrapper/*

--- a/grails-app/assets/javascripts/hubCore.js
+++ b/grails-app/assets/javascripts/hubCore.js
@@ -5,3 +5,5 @@
 //  ?? require html5.js ??
 
 
+
+ 

--- a/grails-app/assets/javascripts/hubCore.js
+++ b/grails-app/assets/javascripts/hubCore.js
@@ -1,5 +1,9 @@
 // hubCore
 //= require jquery_i18n
-// NOT  require jquery.autocomplete
+// NOT require jquery.autocomplete
 // NOT require biocache-hubs.js
 //  ?? require html5.js ??
+
+
+
+ 

--- a/grails-app/assets/javascripts/hubCore.js
+++ b/grails-app/assets/javascripts/hubCore.js
@@ -1,9 +1,5 @@
 // hubCore
 //= require jquery_i18n
-//= require jquery.autocomplete
+// NOT  require jquery.autocomplete
 // NOT require biocache-hubs.js
 //  ?? require html5.js ??
-
-
-
- 

--- a/grails-app/assets/javascripts/hubCore.js
+++ b/grails-app/assets/javascripts/hubCore.js
@@ -5,5 +5,3 @@
 //  ?? require html5.js ??
 
 
-
- 


### PR DESCRIPTION
Update Grails asset-pipeline template to exclude jquery.autocomplete as this is loaded in the layout section.

This was preventing the autocomplete to work on the Global Search Input on the Records pages.